### PR TITLE
Add composite velocity calculated from navVel[]

### DIFF
--- a/index.html
+++ b/index.html
@@ -1397,6 +1397,15 @@
                                     <div>
                                         <label class="option">Units<input class="legend-units ios-switch" type="checkbox"/><div><div></div></div><span>Display actual units on legend.</span></label>
                                     </div>
+                                    <div>
+										<label class="option">Velocity
+										  <select class="velocity-units">
+										    <option value="D">m/s</option>
+										    <option value="M">kph</option>
+										    <option value="I">mph</option>
+										  </select>
+										</label>
+									</div>
                                 </div>
                             </div>
 	                    </div>

--- a/js/flightlog.js
+++ b/js/flightlog.js
@@ -11,7 +11,7 @@
  */
 function FlightLog(logData) {
     var
-        ADDITIONAL_COMPUTED_FIELD_COUNT = 15, /** attitude + PID_SUM + PID_ERROR + RCCOMMAND_SCALED + GYROADC_SCALED **/
+        ADDITIONAL_COMPUTED_FIELD_COUNT = 16, /** attitude + PID_SUM + PID_ERROR + RCCOMMAND_SCALED + GYROADC_SCALED + VELOCITY **/
 
         that = this,
         logIndex = false,
@@ -228,6 +228,7 @@ function FlightLog(logData) {
         fieldNames.push("axisError[0]", "axisError[1]", "axisError[2]"); // Custom calculated error field
         fieldNames.push("rcCommands[0]", "rcCommands[1]", "rcCommands[2]"); // Custom calculated error field
         fieldNames.push("gyroADCs[0]", "gyroADCs[1]", "gyroADCs[2]"); // Custom calculated error field
+		fieldNames.push("velocity");
 
         fieldNameToIndex = {};
         for (i = 0; i < fieldNames.length; i++) {
@@ -513,6 +514,7 @@ function FlightLog(logData) {
 
             sysConfig,
             attitude,
+			navVel = [fieldNameToIndex["navVel[0]"], fieldNameToIndex["navVel[1]"]],
 
             axisPID = [[fieldNameToIndex["axisP[0]"], fieldNameToIndex["axisI[0]"], fieldNameToIndex["axisD[0]"]],
                        [fieldNameToIndex["axisP[1]"], fieldNameToIndex["axisI[1]"], fieldNameToIndex["axisD[1]"]],
@@ -595,6 +597,12 @@ function FlightLog(logData) {
                             (gyroADC[axis] !== undefined ? that.gyroRawToDegreesPerSecond(srcFrame[gyroADC[axis]]) : 0);
                         }
 
+					// Composite velocity from cardinal velocities
+					var
+						velx = srcFrame[navVel[0]],
+						vely = srcFrame[navVel[1]];
+					if (velx !== undefined && vely !== undefined)
+						destFrame[fieldIndex++] = Math.round(Math.hypot(velx, vely));
                 }
             }
         }

--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -280,6 +280,18 @@ function FlightLogFieldPresenter() {
             case 'debug[3]':
             	return FlightLogFieldPresenter.decodeDebugFieldToFriendly(flightLog, fieldName, value, currentFlightMode);
 
+			case 'navVel[0]':
+			case 'navVel[1]':
+			case 'velocity':
+				if (userSettings.velocityUnits == 'I') // Imperial
+					return (value * 0.0223694).toFixed(1) + "mph";
+				if (userSettings.velocityUnits == 'M') // Metric
+					return (value * 0.036).toFixed(1) + "kph";
+				return (value / 100).toFixed(2) + "m/s"; // Default
+
+			case 'navVel[2]': // Vertical speed always in m/s
+				return (value / 100).toFixed(2) + "m/s"; 
+				
             default:
                 return "";
         }

--- a/js/user_settings_dialog.js
+++ b/js/user_settings_dialog.js
@@ -44,6 +44,7 @@ function UserSettingsDialog(dialog, onLoad, onSave) {
 		stickTrails			: false,			// Show stick trails?
 		stickInvertYaw		: false,			// Invert yaw in stick display?
         legendUnits			: true,	            // Show units on legend?
+		velocityUnits		: "D",				// Units for composite velocity "D" / "M" / "I"
 		gapless				: false,
 		drawCraft			: "3D", 
 		drawPidTable		: true, 
@@ -295,6 +296,10 @@ function UserSettingsDialog(dialog, onLoad, onSave) {
         currentSettings.legendUnits = $(this).is(":checked");
     });
 
+    $(".velocity-units").click(function() {
+        currentSettings.velocityUnits = $(this).val();
+    });
+
     // Load Custom Logo
     function readURL(input) {
         if (input.files && input.files[0]) {
@@ -366,6 +371,7 @@ function UserSettingsDialog(dialog, onLoad, onSave) {
 				$(".legend-units").prop('checked', currentSettings.legendUnits);
 			}
 
+			$(".velocity-units").val(currentSettings.velocityUnits || "D");
 
         mixerListSelection(currentSettings.mixerConfiguration); // select current mixer configuration
     		stickModeSelection(currentSettings.stickMode);


### PR DESCRIPTION
I thought it would be nice to have the ground speed available in the log viewer. Sure, there's navVel[] but it is componentized so you need to calculate the vector from the N/S + E/W vectors manually. It can also be exported using blackbox-tools but trying to view the CSV externally and match it up with the loopcnt is tedious at best. This pull request adds a new "velocity" calculated field to the navlog parser.

The navVel value is also in cm/s which isn't a number most people have a reference for so I've added a "Velocity Units" option for the X/Y components of the navVel[] and velocity fields.

### CAVEAT ###
I could not figure out how to automatically set the scale of the velocity field when being displayed on the graph like other fields so it always seems to max out immediately, requiring the user to set an appropriate pen zoom. Can someone point me in the right direction for that? I see that `GraphConfig.getDefaultCurveForField()` should do it, but since there's no fieldstats with a min/max, I just get the default 500 `inputRange`. Any way to get `FlightLogParser.updateFieldStatistics()` to run against the calculated velocity field?