### PR TITLE
Add field presenters for rssi, amperage, vbat, sagCompensatedVBat

### DIFF
--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -292,6 +292,16 @@ function FlightLogFieldPresenter() {
 			case 'navVel[2]': // Vertical speed always in m/s
 				return (value / 100).toFixed(2) + "m/s"; 
 				
+			case 'rssi':
+				return Math.round(value / 10.24) + "%";
+
+			case 'amperage':
+				return (value / 100.0).toFixed(2) + "A";
+
+			case 'vbat':
+			case 'sagCompensatedVBat':
+				return (value / 100.0).toFixed(2) + "V";
+
             default:
                 return "";
         }


### PR DESCRIPTION
Hi Paweł, or whoever is reading this. This tiny pull request just adds some field field presenters for the above blackbox parameters just so they won't be blank in the legend display. I have my "Display actual units on legend." turned on all the time and it's a small inconvenience to have to go to to the table to see an actual value. This isn't a big deal, so if different inav targets log their rssi / voltage / current in different scales (and therefore the fixed scaling I am applying isn't correct), then just close this pull request.

Sorry for making a second pull request after the composite velocity one, I just didn't want to include anything else not specific to that feature.