### PR TITLE
Sync flags and enums with iNav 3, add presenters for unhandled fields

### DIFF
--- a/js/flightlog_fielddefs.js
+++ b/js/flightlog_fielddefs.js
@@ -68,7 +68,21 @@ var
                 "AUTO TUNE",
                 "CAMERA 1",
                 "CAMERA 2",
-                "CAMERA 3"
+                "CAMERA 3",
+                "OSD ALT1",
+                "OSD ALT2",
+                "OSD ALT3",
+                "COURSE HOLD",
+                "BRAKING",
+                "USER 1",
+                "USER 2",
+                "CAM MIX", // FPV Angle Mix
+                "LOITER DIRCH", // Loiter direction change
+                "MSP RC OVER", // MSP RC Override
+                "PREARM",
+                "TURTLE",
+                "NAV CRUISE",
+                "AUTOLEVEL"
         ]),
 
         FLIGHT_LOG_FEATURES = makeReadOnly([
@@ -231,7 +245,17 @@ var
                 "NAV_CRUISE_BRAKING_BOOST",
                 "NAV_CRUISE_BRAKING_LOCKED",
                 "NAV_EXTRA_ARMING_SAFETY_BYPASSED",    // nav_extra_arming_safey was bypassed. Keep it until power cycle.
-                "AIRMODE_ACTIVE"
+                "AIRMODE_ACTIVE",
+                "ESC_SENSOR_ACT",
+                "AIRPLANE",
+                "MULTIROTOR",
+                "ROVER",
+                "BOAT",
+                "ALT_CONTROL", // Altitude control
+                "FORWARD_ONLY", // Move Forward Only
+                "REV_MOTOR_FOR", // Reverse Motors Forward
+                "HEADING_USE_YAW", // FW Heading use yaw
+                "ANTIWINDUP_OFF" // Antiwindup Deactivated
         ]),
 
         FLIGHT_LOG_FAILSAFE_PHASE_NAME = makeReadOnly([
@@ -258,7 +282,6 @@ var
                 "RTH_CLIMB_TO_SAFE_ALT",
                 "RTH_HEAD_HOME",
                 "RTH_HOVER_PRIOR_TO_LANDING",
-                "RTH_HOVER_ABOVE_HOME",
                 "RTH_LANDING",
                 "RTH_FINISHING",
                 "RTH_FINISHED",
@@ -281,7 +304,10 @@ var
                 "CRUISE_2D_ADJUSTING",
                 "CRUISE_3D_INITIALIZE",
                 "CRUISE_3D_IN_PROGRESS",
-                "CRUISE_3D_ADJUSTING"
+                "CRUISE_3D_ADJUSTING",
+                "WAYPOINT_HOLD",
+                "RTH_HOVER_ABOVE_HOME",
+                "UNUSED_4"
         ]),
         
         FLIGHT_LOG_NAV_FLAGS = makeReadOnly([

--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -443,7 +443,7 @@ function FlightLogFieldPresenter() {
         SENSOR_TYPES.forEach((sensor, index) => {
             let status = (healthStatus >> (index * 2)) & 0x03;
             if (status !== 0)
-              retVal += ((retVal) ? " | " : "") +  sensor + SENSOR_STATUS[status];
+                retVal += (retVal ? " | " : "") + sensor + SENSOR_STATUS[status];
         });
         return retVal;
     };

--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -341,6 +341,9 @@ function FlightLogFieldPresenter() {
             case 'features':
                 return presentEnum(value, FLIGHT_LOG_FEATURES);
 
+            case 'hwHealthStatus':
+                return FlightLogFieldPresenter.decodeHwHealth(value);
+
             case 'debug[0]':
             case 'debug[1]':
             case 'debug[2]':
@@ -426,5 +429,17 @@ function FlightLogFieldPresenter() {
         }
 
         return fieldName;
+    };
+
+    FlightLogFieldPresenter.decodeHwHealth = function (healthStatus) {
+        const SENSOR_STATUS = [ "", " OK", " UNAVAIL", " UNHEALTHY" ];
+        const SENSOR_TYPES = [ "GYRO", "ACCEL", "COMP", "BARO", "GPS", "RANGE", "PITOT" ];
+        let retVal = "";
+        SENSOR_TYPES.forEach((sensor, index) => {
+            let status = (healthStatus >> (index * 2)) & 0x03;
+            if (status !== 0)
+              retVal += ((retVal) ? " | " : "") +  sensor + SENSOR_STATUS[status];
+        });
+        return retVal;
     };
 })();

--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -230,7 +230,23 @@ function FlightLogFieldPresenter() {
             case 'rcData[1]':
             case 'rcData[2]':
             case 'rcData[3]':
-                return value.toFixed(0) + " us";
+            case 'servo[0]':
+            case 'servo[1]':
+            case 'servo[2]':
+            case 'servo[3]':
+            case 'servo[4]':
+            case 'servo[5]':
+            case 'servo[6]':
+            case 'servo[7]':
+            case 'servo[8]':
+            case 'servo[9]':
+            case 'servo[10]':
+            case 'servo[11]':
+            case 'servo[12]':
+            case 'servo[13]':
+            case 'servo[14]':
+            case 'servo[15]':
+                return value.toFixed(0) + "us";
 
             case 'axisSum[0]':
             case 'axisSum[1]':

--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -372,6 +372,18 @@ function FlightLogFieldPresenter() {
             case 'sagCompensatedVBat':
                 return (value / 100.0).toFixed(2) + "V";
 
+            case 'IMUTemperature':
+            case 'baroTemperature':
+            case 'sens0Temp':
+            case 'sens1Temp':
+            case 'sens2Temp':
+            case 'sens3Temp':
+            case 'sens4Temp':
+            case 'sens5Temp':
+            case 'sens6Temp':
+            case 'sens7Temp':
+                return (value == -1250) ? "" : (value / 10.0).toFixed(1) + '&deg;';
+
             default:
                 return "";
         }

--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -360,6 +360,8 @@ function FlightLogFieldPresenter() {
             case 'navTgtVel[0]':
             case 'navTgtVel[1]':
             case 'velocity':
+            case 'wind[0]':
+            case 'wind[1]':
             case 'windVelocity':
                 if (userSettings.velocityUnits == 'I') // Imperial
                     return (value * 0.0223694).toFixed(1) + "mph";

--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -260,6 +260,10 @@ function FlightLogFieldPresenter() {
             case 'axisD[0]':
             case 'axisD[1]':
             case 'axisD[2]':
+            case 'fwAltP':
+            case 'fwAltI':
+            case 'fwAltD':
+            case 'fwAltOut':
                 return flightLog.getPIDPercentage(value).toFixed(1) + "%";
 
             case 'mcPosAxisP[0]':

--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -310,7 +310,8 @@ function FlightLogFieldPresenter() {
             case 'heading[0]':
             case 'heading[1]':
             case 'heading[2]':
-                return (value / Math.PI * 180).toFixed(1) + "°";
+            case 'windHeading':
+                return (value / Math.PI * 180).toFixed(1) + "&deg;";
 
             case 'BaroAlt':
                 return (value / 100).toFixed(1) + "m";
@@ -359,6 +360,7 @@ function FlightLogFieldPresenter() {
             case 'navTgtVel[0]':
             case 'navTgtVel[1]':
             case 'velocity':
+            case 'windVelocity':
                 if (userSettings.velocityUnits == 'I') // Imperial
                     return (value * 0.0223694).toFixed(1) + "mph";
                 if (userSettings.velocityUnits == 'M') // Metric
@@ -366,7 +368,8 @@ function FlightLogFieldPresenter() {
                 return (value / 100).toFixed(2) + "m/s"; // Default
 
             case 'navVel[2]': // Vertical speed always in m/s
-            case 'navTgtVel[2]': // Vertical speed always in m/s
+            case 'navTgtVel[2]':
+            case 'wind[2]':
                 return (value / 100).toFixed(2) + "m/s";
 
             case 'rssi':

--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -390,7 +390,7 @@ function FlightLogFieldPresenter() {
                 return (value == -1250) ? "" : (value / 10.0).toFixed(1) + '&deg;';
 
             default:
-                return "";
+                return value.toString();
         }
     };
 

--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -382,6 +382,7 @@ function FlightLogFieldPresenter() {
             case 'sens5Temp':
             case 'sens6Temp':
             case 'sens7Temp':
+            case 'escTemperature':
                 return (value == -1250) ? "" : (value / 10.0).toFixed(1) + '&deg;';
 
             default:

--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -43,7 +43,6 @@ function FlightLogFieldPresenter() {
         'BaroAlt': 'baro',
 
         'servo[all]': 'servos',
-        'servo[5]': 'tail servo',
 
         'heading[all]': 'heading',
         'heading[0]': 'heading[roll]',

--- a/js/header_dialog.js
+++ b/js/header_dialog.js
@@ -176,29 +176,38 @@ function HeaderDialog(dialog, onSave) {
 		var value = sysConfig.features;
 
         var features = [
+            // Order from configurator js/fc.js
             {bit: 1, name: 'VBAT'},
             {bit: 4, name: 'MOTOR_STOP'},
-            {bit: 5, name: 'SERVO_TILT'},
             {bit: 6, name: 'SOFTSERIAL'},
             {bit: 7, name: 'GPS'},
             {bit: 10, name: 'TELEMETRY'},
             {bit: 11, name: 'CURRENT_METER'},
-            {bit: 12, name: '3D'},
+            {bit: 12, name: 'REVERSIBLE_MOTORS'},
             {bit: 15, name: 'RSSI_ADC'},
             {bit: 16, name: 'LED_STRIP'},
-            {bit: 17, name: 'DISPLAY'},
+            {bit: 17, name: 'DASHBOARD'},
             {bit: 19, name: 'BLACKBOX'},
-            {bit: 20, name: 'CHANNEL_FORWARDING'},
-            {bit: 2, name: 'INFLIGHT_ACC_CAL'},
-            {bit: 9, name: 'SONAR'},
-            {bit: 8, name: 'FAILSAFE'},
-            {bit: 18, name: 'ONESHOT125'},
             {bit: 28, name: 'PWM_OUTPUT_ENABLE'},
-            {bit: 21, name: 'TRANSPONDER'},
-            {bit: 26, name: 'SOFTSPI'},
-            {bit: 27, name: 'PWM_SERVO_DRIVER'},
+            {bit: 26, name: 'SOFTSPI'}, // in configurator but not cli features?
             {bit: 29, name: 'OSD'},
-            {bit: 22, name: 'AIRMODE'}
+            {bit: 22, name: 'AIRMODE'},
+            {bit: 30, name: 'FW_LAUNCH'},
+            {bit: 2, name: 'TX_PROF_SEL'},
+            {bit: 0, name: 'THR_VBAT_COMP'},
+            {bit: 3, name: 'BAT_PROF_AUTOSWITCH'},
+            {bit: 31, name: 'FW_AUTOTRIM'},
+
+            // Dynamic features
+            {bit: 5, name: 'DYNAMIC_FILTERS'}, // iNav 2.4.0 < 2.5.0
+
+            // Target features
+            {bit: 21, name: 'TRANSPONDER'}
+
+            // Unused bits
+            //{bit: 8, name: 'RPM_FILTERS'},
+            //{bit: 23, name: 'SUPEREXPO'},
+            // {bit: 24, name: 'VTX'},
         ];
 
         var features_e = $('.features');


### PR DESCRIPTION
## Flags and Enums
I've updated all the flags and enums in the blackbox viewer to match what's currently in iNav 3.0.0 tag for flightModeFlags, stateFlags, navState. In addition I've updated the feature list in header_dialog to match the current features list as well.

This PR supersedes #47, so taking this PR would also satisfy that one.

## Presenters
In addition, I've updated the presenters to provide displayable values for all fields. It stinks to have to open the Table view constantly because there's no presenter for some fields so the Legend view just displays it as ` ()`.
* Servo[] is displayed as us
* Temperatures are displayed via decidegrees, except -1250 which will still be blank
* Add hwHealthStatus presenter that parses diagnostic flags for "GYRO", "ACCEL", "COMP", "BARO", "GPS", "RANGE", "PITOT"
* fwAltP, fwAltI, fwAltD, fwAltOut get decidegres as well as that's what the fw_alt PID uses. I didn't do fwPosX because the value may be decidegrees but the inav code says centidegrees and I am not sure what units these are. I can push an update if someone can tell me fore sure.
* If no matching presenter is found, just use the value, since it helps to display something in the Legend. It might be nice to have them be blank in the Table view but not in the Legend view, but there are so few values that don't have handlers, there wouldn't be much purpose in having two implementations.

## Wind
* wind[] I am not sure of the units here but I've added new virtual fields to compute wind speed and heading from the wind[] vector. I've also added presenters for these fields. I am assuming that heading 0 is +Y, so let me know if the units are wrong here but I checked a handful of logs and it seems to be correctish.

## tail servo
I've also removed the "friendly name" for servo[5] being called "tail servo". Know where **any other place in iNav** that specifically relabels servo 5 as "tail servo"? Me neither. Know exactly how many people use servo 5 as a tail servo? Maybe 1? None of the other servos have aliases, let's stop giving this one an alias that is wrong almost 100% of the time.

## Missing presenters
* escRPM not sure if this is eRPM or RPM because I don't have any DSHOT ESCs running iNav
* fwPosX because I am not sure if this is decidegrees, centidegrees or other
