### PR TITLE
Adjust log/video distinction

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -893,7 +893,9 @@ function BlackboxLogViewer() {
                     isWorkspaces = files[i].name.match(/\.(JSON)$/i);
                 
                 if (!isLog && !isVideo && !isWorkspaces) {
-                    if (files[i].size < 10 * 1024 * 1024)
+                    if (files[i].name.match(/blackbox_log/i))
+                        isLog = true;
+                    else if (files[i].size < 32 * 1024 * 1024)
                         isLog = true; //Assume small files are logs rather than videos
                     else
                         isVideo = true;


### PR DESCRIPTION
I was wondering why some logs failed to open and others worked fine. It turns out that, since my log files didn't have an extension, it only used the size to distinguish between logs and video. I used the default names for my log files as suggested by iNav Configurator (it might be a separate issue that the default is extensionless - at least on Linux).

My changes:
- Consider everything (except for known extensions) containing `blackbox_log` as logs. This should cover the default file names as exported by iNav Configurator.
- Increase the log/video size boundary to 32MiB, as that seems to be a common size for flight controller flash chips.

I suspect this would resolve issues #56 and #58.