### PR TITLE
Add navState to status bar, tooltips for each field

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -957,7 +957,7 @@ html:not(.has-config) #status-bar .configuration-file-name {
     float: left;
     padding-right: 5px;
     margin-right: 5px;
-    border-right: 1px solid #7d7d79;
+    border-right: 1px solid #a94442;
 }
 
 #status-bar div:first-child {

--- a/index.html
+++ b/index.html
@@ -484,22 +484,25 @@
     <!-- Status Bar -->
     <div id="status-bar">
         <div>
-            <span class="version">-</span>
+            <span class="version" title="iNav Version / Target">-</span>
         </div>
         <div>
-            <span class="log-cells">-</span>
+            <span class="log-cells" title="Battery Cells">-</span>
         </div>
         <div>
-            <span class="looptime">-</span>
+            <span class="looptime" title="Looptime">-</span>
         </div>
         <div>
-            <span class="lograte">-</span>
+            <span class="lograte" title="Log Sample Rate">-</span>
         </div>
         <div>
-            <span class="flight-mode">-</span>
+            <span class="flight-mode" title="Flight Mode">-</span>
         </div>
         <div>
-            <span class="marker-offset">00:00.000</span>
+            <span class="nav-state" title="Navigation State">-</span>
+        </div>
+        <div>
+            <span class="marker-offset" title="Marker Offset">00:00.000</span>
         </div>
         <div>
             <span class="overrides"></span>
@@ -538,7 +541,7 @@
             <span class="configuration-file-name">-</span>
         </div>
         <div>
-            <span class="viewer-version">-</span>
+            <span class="viewer-version" title="Blackbox Explorer Version">-</span>
         </div>
     </div>
 	<!-- Dialog Boxes and Popup Windows -->

--- a/js/main.js
+++ b/js/main.js
@@ -192,10 +192,14 @@ function BlackboxLogViewer() {
                 
             }
 
-            // Update flight mode flags on status bar
+            // Update flight mode and nav state flags on status bar
             $(".flight-mode", statusBar).text(
-            		fieldPresenter.decodeFieldToFriendly(null, 'flightModeFlags', currentFlightMode, null)	
-            	);
+                    fieldPresenter.decodeFieldToFriendly(null, 'flightModeFlags', currentFlightMode, null)
+                );
+            var currentNavState = frame[flightLog.getMainFieldIndexByName("navState")];
+            $(".nav-state", statusBar).text(
+                    fieldPresenter.decodeFieldToFriendly(null, 'navState', currentNavState, null)
+                );
 
             // update time field on status bar
             $(".graph-time").val(formatTime((currentBlackboxTime-flightLog.getMinTime())/1000, true));


### PR DESCRIPTION
This adds a new field to the status bar of a log view, the navState field. I was having a hard time determining when I was in CRUISE mode during a flight because that information isn't part of the fligthMode flags, and there's room so why not right?

* Add navState to status bar
* Added mouseover tooltips to each of the fields to be clear about what information is being displayed
* Changed the field separator color from gray to a dark red. The flightMode flags field uses a text pipe to split the flags, which looks incredibly similar to the field separator so it always looks like new fields are always coming and going, so this makes it clear what fields are in what box. If this was designed for that to be visually ambiguous like that, then I can revert that part of the PR.

![image](https://user-images.githubusercontent.com/677183/236486476-342fb1e4-69db-491e-a48d-9a5cd18be067.png)

I do not know what the overrides and config file status bar fields are for, so if someone wants to pick the tooltip for those, I can add those as well.