### PR TITLE
Min. Zoom to 2%

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -32,10 +32,10 @@ function BlackboxLogViewer() {
         PLAYBACK_MAX_RATE = 300,
         PLAYBACK_DEFAULT_RATE = 100,
         PLAYBACK_RATE_STEP = 5,
-        GRAPH_MIN_ZOOM = 10,
+        GRAPH_MIN_ZOOM = 2,
         GRAPH_MAX_ZOOM = 1000,
         GRAPH_DEFAULT_ZOOM = 100,
-        GRAPH_ZOOM_STEP = 10;
+        GRAPH_ZOOM_STEP = 2;
     
     var
         graphState = GRAPH_STATE_PAUSED,


### PR DESCRIPTION
Changes min. zoom on main windows to 2% and increment to 2 to allow for a bigger look at the log for NAV moves troublehshooting and tuning.  This helps to pick up on patterns, specifically on sensors accuracy effecting the desired results.

![image](https://github.com/iNavFlight/blackbox-log-viewer/assets/25570978/3a6029c8-c3f8-4d4d-9dd1-c992eb730c1d)
