### PR TITLE
add a second Timer window where always sec are shown

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -697,6 +697,13 @@ html.has-marker .graph-time-marker-group > .graph-time-marker {
     display:inline-block;
 }
 
+html .graph-time-marker-group2 > .graph-time-marker2 {
+    display:none;
+}
+html.has-marker2 .graph-time-marker-group2 > .graph-time-marker2 {
+    display:inline-block;
+}
+
 .log-metadata, .log-field-values {
     display:none;
 }

--- a/index.html
+++ b/index.html
@@ -371,6 +371,14 @@
                     </div>
                 </div>
             </li>
+            <li class="log-chart-time-panel small-screen">
+                <h4>Time always sec</h4>
+                <div class="form-inline">
+                    <div class="form-group">
+                        <input type="text" class="form-control graph-time2" value="1.0" size="8" data-toggle="tooltip" title="Enter a time to jump to">
+                    </div>
+                </div>
+            </li>
             <li class="log-sync-panel">
                 <h4>Log sync</h4>
                 <div class="form-inline">

--- a/js/main.js
+++ b/js/main.js
@@ -203,6 +203,7 @@ function BlackboxLogViewer() {
 
             // update time field on status bar
             $(".graph-time").val(formatTime((currentBlackboxTime-flightLog.getMinTime())/1000, true));
+            $(".graph-time2").val(((currentBlackboxTime-flightLog.getMinTime())/1000000).toFixed(3));
             if(hasMarker) {
                 $(".marker-offset", statusBar).text('Marker Offset ' + formatTime((currentBlackboxTime-markerTime)/1000, true) + 'ms ' + (1000000/(currentBlackboxTime-markerTime)).toFixed(0) + "Hz");
             }


### PR DESCRIPTION
I use PID Tunning Tool and if you have a long flight and want to select something in PIDTunning tool there is always only seconds and not minutes. So the second Timer always shows secands also if >60sec