### PR TITLE
Add a toggle to display the time in minutes/seconds (current) or in seconds only (new)

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -697,6 +697,11 @@ html.has-marker .graph-time-marker-group > .graph-time-marker {
     display:inline-block;
 }
 
+.user-settings-dialog .time-switch-group img {
+	width: 125px;
+	max-height: 125px;
+}
+
 .log-metadata, .log-field-values {
     display:none;
 }

--- a/index.html
+++ b/index.html
@@ -371,6 +371,14 @@
                     </div>
                 </div>
             </li>
+            <li class="log-chart-time-panel small-screen">
+                <h4>Timeswitch</h4>
+                <div class="form-inline">
+                    <div class="form-group">
+                        <label class="option"><input class="time-switch ios-switch" type="checkbox"/><div><div></div></div><span>Show Sec or Min</span></label>
+                    </div>
+                </div>
+            </li>
             <li class="log-sync-panel">
                 <h4>Log sync</h4>
                 <div class="form-inline">

--- a/js/main.js
+++ b/js/main.js
@@ -202,7 +202,13 @@ function BlackboxLogViewer() {
                 );
 
             // update time field on status bar
-            $(".graph-time").val(formatTime((currentBlackboxTime-flightLog.getMinTime())/1000, true));
+            if($(".time-switch").is(":checked")) {
+                // only seconds
+                $(".graph-time").val(((currentBlackboxTime-flightLog.getMinTime())/1000000).toFixed(3));
+            } else {
+                // minutes and seconds
+                $(".graph-time").val(formatTime((currentBlackboxTime-flightLog.getMinTime())/1000, true));
+            }
             if(hasMarker) {
                 $(".marker-offset", statusBar).text('Marker Offset ' + formatTime((currentBlackboxTime-markerTime)/1000, true) + 'ms ' + (1000000/(currentBlackboxTime-markerTime)).toFixed(0) + "Hz");
             }


### PR DESCRIPTION
Add a switch that displays seconds, even if the duration exceeds 60 seconds. This is particularly useful when using the PID Tuning Tool during long flights, where precise timing in seconds is essential for selecting parameters.

![grafik](https://github.com/iNavFlight/blackbox-log-viewer/assets/18383738/37c4a616-f882-4b30-b41d-4877f3908492)
and with switch on:
![grafik](https://github.com/iNavFlight/blackbox-log-viewer/assets/18383738/d7e4225f-6d19-400d-9f44-4b391dca851c)
